### PR TITLE
Add bulk import mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ MEDIA_PORT=3312
 ADMINER_PORT=3313
 SOLR_PORT=8983
 
+TRACE_IMPORT_MODE=false # Bulk import mode
+
 NEXT_PUBLIC_API_ENDPOINT=http://localhost:3311    # external URL
 NEXT_PUBLIC_MEDIA_ENDPOINT=http://localhost:3312  # external URL
 
@@ -108,7 +110,7 @@ sudo chown 8983:8983 mycores
 ### Starting the cluster
 
 ```bash
-docker-compose up
+docker-compose up -d --force-recreate
 ```
 
 ### Importing media files
@@ -130,3 +132,10 @@ Files must have the `.mp4` extension and must be in the mp4 format inorder to be
 Do not create the folders in the incoming directory. You should first put video files in folders, then move or copy the folders into the incoming directory.
 
 Once the video files are in incoming directory, the watcher would start uploading the video to trace.moe-media. When it's done, it would delete the video in incoming directory. After Hash worker and Load workers complete the job, you can search the video by image in your www website at WWW_PORT.
+
+### Bulk import mode
+
+It is possible to import data in bulk. When the application is started with `TRACE_IMPORT_MODE` set to `true`, it will disable search, rate limiting of API requests and auto commiting when the loader submits media to Solr. This is done so the internal systems go as fast as possible.
+The default value is `false`.
+
+When you are finished importing. Make sure you commit your files in your Solr cluster(s) before you turn it off. This can be done by manually visiting the update commit for your cluster(s). The default is: `http://localhost:8983/solr/cl_0/update?commit=true`. It might take a while for the cluster to fully process the imported documents.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
         source: ${MEDIA_DIR}
         target: /mnt/
     networks:
-      trace_moe_net:        
+      trace_moe_net:
 
   api:
     image: ghcr.io/soruly/trace.moe-api:latest
@@ -50,6 +50,7 @@ services:
       - TRACE_MEDIA_SALT=${TRACE_MEDIA_SALT}
       - TRACE_API_SECRET=${TRACE_API_SECRET}
       - TRACE_API_SALT=${TRACE_API_SALT}
+      - TRACE_IMPORT_MODE=${TRACE_IMPORT_MODE}
       - TRACE_ACCURACY=0.03
       - HASH_PATH=/mnt/hash
     ports:
@@ -116,7 +117,7 @@ services:
         soft: 1000000
         hard: 1000000
     networks:
-      trace_moe_net:        
+      trace_moe_net:
 
   loader:
     image: ghcr.io/soruly/trace.moe-worker-loader:latest
@@ -125,6 +126,7 @@ services:
       - TRACE_API_URL=http://172.17.0.1:${API_PORT}
       - TRACE_API_SECRET=${TRACE_API_SECRET}
       - TRACE_MEDIA_URL=http://172.17.0.1:${MEDIA_PORT}
+      - TRACE_IMPORT_MODE=${TRACE_IMPORT_MODE}
     networks:
       trace_moe_net:
 
@@ -141,7 +143,7 @@ services:
         source: ${WATCH_DIR}
         target: /mnt/
     networks:
-      trace_moe_net:        
+      trace_moe_net:
 
 networks:
   trace_moe_net:


### PR DESCRIPTION
The bulk import mode allows administrators and developers to setup a new cluster and import existing hashes without getting bottlenecks due to rate limiting or Solr commits. It increases the import speed sigificantly. This feature is spread accross multiple PRs.

Changes:

Documentation:
 - Added environment flag and usage documentation.

API:
 - Disable rate limiting when import mode is enabled.
 - Disable search with a error message to prevent accidental production deploys.

Loader:
 - Disable commiting when import mode is enabled.

